### PR TITLE
Modified Typescript version to 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "protractor": "^5.1.2",
     "ts-node": "^3.0.6",
     "tslint": "^5.4.3",
-    "typescript": "^2.3.4"
+    "typescript": "2.4.0"
   },
   "keywords": [
     "esta-webjs-starterkit",


### PR DESCRIPTION
- old version does not work with rxjs together (app cannot be started)
- version needs to be a clean one without carret
- see also https://stackoverflow.com/questions/44793859/rxjs-subject-d-ts-error-class-subjectt-incorrectly-extends-base-class-obs