### PR TITLE
Use npm ci instead of npm install in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,7 +10,7 @@ pipeline {
 
     stage('Prepare') {
       steps {
-        sh 'npm install'
+        sh 'npm ci'
         sh 'npm run lint'
       }
     }


### PR DESCRIPTION
npm ci is now available in Jenkins nodejs agents and should thus be used instead of the less performant npm install